### PR TITLE
Integrate Opensource MediaSDK OpenMAX Plugin to 1A

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,12 +1,13 @@
 ifeq ($(USE_MEDIASDK),true)
-  LOCAL_PATH := $(call my-dir)
-  include $(CLEAR_VARS)
+  ifneq ($(BOARD_HAVE_OMX_SRC), true)
+    LOCAL_PATH := $(call my-dir)
+    include $(CLEAR_VARS)
 
-  LOCAL_PROPRIETARY_MODULE := true
+    LOCAL_PROPRIETARY_MODULE := true
 
-  MEDIASDK_BIN_REPO := $(LOCAL_PATH)
+    MEDIASDK_BIN_REPO := $(LOCAL_PATH)
 
-  # Call appropriate Android.mk for the platform
-  include $(MEDIASDK_BIN_REPO)/mediasdk/Android.mk
-
+    # Call appropriate Android.mk for the platform
+    include $(MEDIASDK_BIN_REPO)/mediasdk/Android.mk
+  endif
 endif


### PR DESCRIPTION
This change is to disable closed mediasdk openmax plugin release.

Tracked-On: https://jira.devtools.intel.com/browse/OAM-76499
Signed-off-by: tianmi.chen <tianmi.chen@intel.com>